### PR TITLE
chore: remove @react-native/dev-middleware dep

### DIFF
--- a/.changeset/mighty-rats-try.md
+++ b/.changeset/mighty-rats-try.md
@@ -1,0 +1,5 @@
+---
+'@rock-js/plugin-metro': patch
+---
+
+chore: remove @react-native/dev-middleware dep

--- a/packages/plugin-metro/package.json
+++ b/packages/plugin-metro/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@react-native-community/cli-server-api": "^19.1.0",
-    "@react-native/dev-middleware": "^0.80.1",
     "@rock-js/tools": "^0.9.0",
     "metro": "^0.82.2",
     "metro-config": "^0.82.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,9 +287,6 @@ importers:
       '@react-native-community/cli-server-api':
         specifier: ^19.1.0
         version: 19.1.1
-      '@react-native/dev-middleware':
-        specifier: ^0.80.1
-        version: 0.80.1
       '@rock-js/tools':
         specifier: ^0.9.0
         version: link:../tools
@@ -311,6 +308,9 @@ importers:
     devDependencies:
       '@react-native/community-cli-plugin':
         specifier: 0.80.1
+        version: 0.80.1
+      '@react-native/dev-middleware':
+        specifier: ^0.80.1
         version: 0.80.1
       '@rock-js/config':
         specifier: ^0.9.0


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Remove unnecessary dependency on `@react-native/dev-middleware` now that we resolve it from `react-native` package

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
