### PR TITLE
fix: make sure new ios project has properly configured iOS options

### DIFF
--- a/.changeset/happy-parrots-return.md
+++ b/.changeset/happy-parrots-return.md
@@ -1,0 +1,6 @@
+---
+'@rock-js/platform-apple-helpers': patch
+'@rock-js/tools': patch
+---
+
+fix: make sure new ios project has properly configured iOS options

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["nrwl.angular-console", "esbenp.prettier-vscode"]
+  "recommendations": ["esbenp.prettier-vscode"]
 }

--- a/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/buildApp.ts
@@ -49,9 +49,11 @@ export async function buildApp({
       scheme: args.scheme,
       xcodeProject: projectConfig.xcodeProject,
       sourceDir: projectConfig.sourceDir,
+      didInstallPods: false,
     };
   }
 
+  let didInstallPods = false;
   let { xcodeProject, sourceDir } = projectConfig;
 
   if (args.installPods) {
@@ -75,6 +77,7 @@ export async function buildApp({
       xcodeProject = newProjectConfig.xcodeProject;
       sourceDir = newProjectConfig.sourceDir;
     }
+    didInstallPods = true;
   }
 
   const info = await getInfo(xcodeProject, sourceDir);
@@ -123,6 +126,7 @@ export async function buildApp({
     xcodeProject,
     sourceDir,
     bundleIdentifier: buildSettings.bundleIdentifier,
+    didInstallPods,
   };
 }
 

--- a/packages/tools/src/lib/build-cache/common.ts
+++ b/packages/tools/src/lib/build-cache/common.ts
@@ -4,6 +4,7 @@ import { color } from '../color.js';
 import type { FingerprintSources } from '../fingerprint/index.js';
 import { nativeFingerprint } from '../fingerprint/index.js';
 import { isInteractive } from '../isInteractive.js';
+import logger from '../logger.js';
 import { getCacheRootPath } from '../project.js';
 import { spinner } from '../prompts.js';
 
@@ -104,12 +105,14 @@ export async function formatArtifactName({
   root,
   fingerprintOptions,
   raw,
+  silent,
 }: {
   platform?: 'ios' | 'android';
   traits?: string[];
   root: string;
   fingerprintOptions: FingerprintSources;
   raw?: boolean;
+  silent?: boolean;
 }): Promise<string> {
   if (!platform || !traits) {
     return '';
@@ -123,7 +126,7 @@ export async function formatArtifactName({
     return `rock-${platform}-${traits.join('-')}-${hash}`;
   }
 
-  const loader = spinner();
+  const loader = spinner({ silent });
   loader.start('Calculating project fingerprint');
   const { hash } = await nativeFingerprint(root, {
     ...fingerprintOptions,
@@ -132,6 +135,9 @@ export async function formatArtifactName({
   loader.stop(
     `Calculated project fingerprint: ${color.bold(color.magenta(hash))}`,
   );
+  if (silent) {
+    logger.debug(`Calculated project fingerprint: ${hash}`);
+  }
   return `rock-${platform}-${traits.join('-')}-${hash}`;
 }
 

--- a/packages/tools/src/lib/build-cache/getBinaryPath.ts
+++ b/packages/tools/src/lib/build-cache/getBinaryPath.ts
@@ -79,6 +79,7 @@ async function warnIgnoredFiles(
     ...(fingerprintOptions?.ignorePaths ?? []),
     ...EXPO_DEFAULT_IGNORE_PATHS,
     ...DEFAULT_IGNORE_PATHS,
+    // TODO: add here ios workspace path
   ];
   const { output } = await spawn('git', [
     'clean',

--- a/packages/tools/src/lib/build-cache/getBinaryPath.ts
+++ b/packages/tools/src/lib/build-cache/getBinaryPath.ts
@@ -79,7 +79,6 @@ async function warnIgnoredFiles(
     ...(fingerprintOptions?.ignorePaths ?? []),
     ...EXPO_DEFAULT_IGNORE_PATHS,
     ...DEFAULT_IGNORE_PATHS,
-    // TODO: add here ios workspace path
   ];
   const { output } = await spawn('git', [
     'clean',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

when running `run:ios` in new project it shouldn't give any warnings, especially related to fingerprint. 

this PR adds `ios/x.xcworkspace` to default ignore paths and adds running the fingerprint once again after pod install was run—as it most likely changes the fingerprint—and before saving to cache. This way, next time a user runs the `run:ios` or `build:ios` commands they'll have a cache hit (which doesn't happen currently)