### PR TITLE
fix: skip git clean -xdf --dry-run check if not git repo

### DIFF
--- a/.changeset/thick-onions-trade.md
+++ b/.changeset/thick-onions-trade.md
@@ -1,0 +1,5 @@
+---
+'@rock-js/tools': patch
+---
+
+fix: skip git clean -xdf --dry-run check if not git repo

--- a/packages/tools/src/lib/build-cache/getBinaryPath.ts
+++ b/packages/tools/src/lib/build-cache/getBinaryPath.ts
@@ -64,6 +64,13 @@ async function warnIgnoredFiles(
   fingerprintOptions: FingerprintSources,
   sourceDir: string,
 ) {
+  try {
+    await spawn('git', ['rev-parse', '--git-dir'], { cwd: sourceDir });
+  } catch {
+    // Not a git repository, skip the git clean check
+    return;
+  }
+
   const ignorePaths = [
     ...(fingerprintOptions?.ignorePaths ?? []),
     ...EXPO_DEFAULT_IGNORE_PATHS,

--- a/packages/tools/src/lib/build-cache/getBinaryPath.ts
+++ b/packages/tools/src/lib/build-cache/getBinaryPath.ts
@@ -64,8 +64,12 @@ async function warnIgnoredFiles(
   fingerprintOptions: FingerprintSources,
   sourceDir: string,
 ) {
+  // @todo unify git helpers from create-app
   try {
-    await spawn('git', ['rev-parse', '--git-dir'], { cwd: sourceDir });
+    await spawn('git', ['rev-parse', '--is-inside-work-tree'], {
+      stdio: 'ignore',
+      cwd: sourceDir,
+    });
   } catch {
     // Not a git repository, skip the git clean check
     return;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

fixes:
<img width="2668" height="1378" alt="CleanShot 2025-08-23 at 16 17 26@2x" src="https://github.com/user-attachments/assets/2230c6cb-8b32-417c-8920-8be49ea2bed1" />



we can't execute `git clean -xdf` in the directory which is not git repo.

