### PR TITLE
chore: update no git remote warning

### DIFF
--- a/.changeset/seven-wings-rule.md
+++ b/.changeset/seven-wings-rule.md
@@ -1,0 +1,6 @@
+---
+'@rock-js/provider-github': patch
+'@rock-js/tools': patch
+---
+
+chore: update no git remote warning

--- a/packages/provider-github/src/lib/config.ts
+++ b/packages/provider-github/src/lib/config.ts
@@ -43,6 +43,11 @@ export type GitHubRepoDetails = {
 
 export async function detectGitHubRepoDetails(): Promise<GitHubRepoDetails> {
   const gitRemote = await getGitRemote();
+
+  if (!gitRemote) {
+    throw new RockError(`No git remote found for GitHub repository.`);
+  }
+
   try {
     const { output: url } = await spawn(
       'git',

--- a/packages/tools/src/lib/build-cache/getBinaryPath.ts
+++ b/packages/tools/src/lib/build-cache/getBinaryPath.ts
@@ -48,8 +48,13 @@ export async function getBinaryPath({
       const message = (error as RockError).message;
       const cause = (error as RockError).cause;
       logger.warn(
-        `Failed to fetch cached build for ${artifactName}: \n${message}`,
-        cause ? `\nCause: ${cause.toString()}` : '',
+        `Remote Cache: Failed to fetch cached build for ${color.bold(
+          artifactName,
+        )}.
+Cause: ${message}${cause ? `\n${cause.toString()}` : ''}
+Read more: ${colorLink(
+          'https://rockjs.dev/docs/configuration#remote-cache-configuration',
+        )}`,
       );
       await warnIgnoredFiles(fingerprintOptions, sourceDir);
       logger.debug('Remote cache failure error:', error);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Avoid checking "null" git remote and make the warning more approachable with link to the docs on remote cache.

<img width="840" height="81" alt="image" src="https://github.com/user-attachments/assets/e7cf9f5b-1f5d-4d94-824a-0835e1c4c6ed" />


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
