### PR TITLE
fix(create-app): get package manager from lock correctly

### DIFF
--- a/.changeset/angry-donkeys-feel.md
+++ b/.changeset/angry-donkeys-feel.md
@@ -1,0 +1,5 @@
+---
+'create-rock': patch
+---
+
+fix(create-app): get package manager from lock correctly

--- a/packages/create-app/src/lib/utils/getPkgManager.ts
+++ b/packages/create-app/src/lib/utils/getPkgManager.ts
@@ -16,7 +16,10 @@ export function getPkgManagerFromLockFile() {
   if (fs.existsSync(path.join(process.cwd(), 'pnpm-lock.yaml'))) {
     return 'pnpm';
   }
-  if (fs.existsSync(path.join(process.cwd(), 'yarn.lock'))) {
+  if (
+    fs.existsSync(path.join(process.cwd(), 'yarn.lock')) ||
+    fs.existsSync(path.join(process.cwd(), '.yarn'))
+  ) {
     return 'yarn';
   }
   if (

--- a/packages/create-app/src/lib/utils/getPkgManager.ts
+++ b/packages/create-app/src/lib/utils/getPkgManager.ts
@@ -9,6 +9,10 @@ export function getPkgManager() {
   if (fromUserAgent) {
     return fromUserAgent.name;
   }
+  return getPkgManagerFromLockFile();
+}
+
+export function getPkgManagerFromLockFile() {
   if (fs.existsSync(path.join(process.cwd(), 'pnpm-lock.yaml'))) {
     return 'pnpm';
   }

--- a/packages/create-app/src/lib/utils/initInExistingProject.ts
+++ b/packages/create-app/src/lib/utils/initInExistingProject.ts
@@ -11,10 +11,10 @@ import {
   spawn,
   spinner,
 } from '@rock-js/tools';
-import { getPkgManager } from './getPkgManager.js';
+import { getPkgManagerFromLockFile } from './getPkgManager.js';
 
 export async function initInExistingProject(projectRoot: string) {
-  const pkgManager = getPkgManager();
+  const pkgManager = getPkgManagerFromLockFile();
 
   const loader = spinner();
 

--- a/packages/create-app/src/lib/utils/migrateRnefProject.ts
+++ b/packages/create-app/src/lib/utils/migrateRnefProject.ts
@@ -2,10 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { SubprocessError } from '@rock-js/tools';
 import { color, logger, note, outro, spawn, spinner } from '@rock-js/tools';
-import { getPkgManager } from './getPkgManager.js';
+import { getPkgManagerFromLockFile } from './getPkgManager.js';
 
 async function migrateRnefProject(projectRoot: string): Promise<void> {
-  const pkgManager = getPkgManager();
+  const pkgManager = getPkgManagerFromLockFile();
   const loader = spinner();
 
   const packagesMap: Record<string, string> = {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We want to have 2 ways of inferring package manager: 
- from user agent (when creating app from scratch)
- from lock file (when initing in existing RNC CLI project or migrating from RNEF)

### Test plan

<img width="336" height="70" alt="image" src="https://github.com/user-attachments/assets/3ed9dd43-9656-4a55-81f3-a5708d747c8d" />

