### PR TITLE
fix: run only on connected Android devices

### DIFF
--- a/.changeset/yummy-lions-wait.md
+++ b/.changeset/yummy-lions-wait.md
@@ -1,0 +1,20 @@
+---
+'@rock-js/platform-android': patch
+'rock': patch
+'@rock-js/config': patch
+'create-rock': patch
+'@rock-js/platform-apple-helpers': patch
+'@rock-js/platform-ios': patch
+'@rock-js/plugin-brownfield-android': patch
+'@rock-js/plugin-brownfield-ios': patch
+'@rock-js/plugin-metro': patch
+'@rock-js/plugin-repack': patch
+'@rock-js/provider-github': patch
+'@rock-js/provider-s3': patch
+'@rock-js/test-helpers': patch
+'@rock-js/tools': patch
+'@rock-js/welcome-screen': patch
+'rock-docs': patch
+---
+
+fix: run only on connected Android devices

--- a/packages/platform-android/src/lib/commands/runAndroid/runAndroid.ts
+++ b/packages/platform-android/src/lib/commands/runAndroid/runAndroid.ts
@@ -104,7 +104,9 @@ export async function runAndroid(
     }
 
     for (const device of await listAndroidDevices()) {
-      await runOnDevice({ device, androidProject, args, tasks, binaryPath });
+      if (device.connected) {
+        await runOnDevice({ device, androidProject, args, tasks, binaryPath });
+      }
     }
   }
 

--- a/packages/platform-android/template/android/app/src/main/res/values/styles.xml
+++ b/packages/platform-android/template/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     </style>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Avoid the "Failed: install and launch" message when multiple Android devices are available but not connected.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
