### PR TITLE
fix(create-app): use compact format for empty plugins array

### DIFF
--- a/.changeset/puny-papers-wink.md
+++ b/.changeset/puny-papers-wink.md
@@ -1,0 +1,5 @@
+---
+'create-rock': patch
+---
+
+Skip adding `plugins` property if no plugins

--- a/packages/create-app/src/lib/bin.ts
+++ b/packages/create-app/src/lib/bin.ts
@@ -322,7 +322,7 @@ export function formatConfig(
     .join('\n')}
 
 export default {${
-    pluginsWithImports
+    pluginsWithImports && pluginsWithImports.length > 0
       ? `
   plugins: [
     ${pluginsWithImports


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

when in create-app user didn't choose any plugins, let's skip adding the plugins property

before:

```js
import { platformIOS } from '@rock-js/platform-ios';
import { platformAndroid } from '@rock-js/platform-android';
import { pluginMetro } from '@rock-js/plugin-metro';

export default {
  plugins: [
    
  ],
  bundler: pluginMetro(),
  platforms: {
    ios: platformIOS(),
    android: platformAndroid(),
  },
  remoteCacheProvider: null,
};
```

after:


```js
import { platformIOS } from '@rock-js/platform-ios';
import { platformAndroid } from '@rock-js/platform-android';
import { pluginMetro } from '@rock-js/plugin-metro';

export default {
  bundler: pluginMetro(),
  platforms: {
    ios: platformIOS(),
    android: platformAndroid(),
  },
  remoteCacheProvider: null,
};

```

