### PR TITLE
fix: skip remoteCacheProvider property when null

### DIFF
--- a/packages/create-app/src/lib/bin.ts
+++ b/packages/create-app/src/lib/bin.ts
@@ -336,9 +336,10 @@ export default {${
     ${platformsWithImports
       .map((template) => `${template.name}: ${template.importName}(),`)
       .join('\n    ')}
-  },
-  remoteCacheProvider: ${
-    remoteCacheProvider === null ? null : `'${remoteCacheProvider}'`
+  }${
+    remoteCacheProvider !== null
+      ? `,\n  remoteCacheProvider: '${remoteCacheProvider}'`
+      : ''
   },
 };
 `;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

before:

```js
import { platformIOS } from '@rock-js/platform-ios';
import { platformAndroid } from '@rock-js/platform-android';
import { pluginMetro } from '@rock-js/plugin-metro';

export default {
  bundler: pluginMetro(),
  platforms: {
    ios: platformIOS(),
    android: platformAndroid(),
  },
  remoteCacheProvider: null,
};
```

after

```js
import { platformIOS } from '@rock-js/platform-ios';
import { platformAndroid } from '@rock-js/platform-android';
import { pluginMetro } from '@rock-js/plugin-metro';

export default {
  bundler: pluginMetro(),
  platforms: {
    ios: platformIOS(),
    android: platformAndroid(),
  }
};
```