### PR TITLE
fix: properly take env value into account; hash sensitive data

### DIFF
--- a/.changeset/sweet-apples-camp.md
+++ b/.changeset/sweet-apples-camp.md
@@ -1,0 +1,6 @@
+---
+'@rock-js/tools': patch
+'rock': patch
+---
+
+fix: properly take env value into account; hash sensitive data

--- a/packages/tools/src/lib/fingerprint/index.ts
+++ b/packages/tools/src/lib/fingerprint/index.ts
@@ -7,6 +7,7 @@ import {
   getDefaultIgnorePaths,
   getPlatformDirIgnorePaths,
 } from './ignorePaths.js';
+export type { FingerprintInputHash } from 'fs-fingerprint';
 
 export type FingerprintSources = {
   extraSources: string[];
@@ -61,6 +62,15 @@ export async function nativeFingerprint(
     throw new Error('No platforms found in autolinking project config');
   }
 
+  let env = undefined;
+
+  if (options.env.length > 0) {
+    env = options.env.reduce((acc: Record<string, string>, key: string) => {
+      acc[key] = process.env[key] ?? '';
+      return acc;
+    }, {});
+  }
+
   const fingerprint = await calculateFingerprint(projectRoot, {
     ignoreFilePath: '.gitignore',
     include: [
@@ -79,7 +89,7 @@ export async function nativeFingerprint(
         key: 'reactNativeVersion',
         json: { version: getReactNativeVersion(projectRoot) },
       },
-      ...(options.env.length > 0 ? [{ key: 'env', json: options.env }] : []),
+      ...(env ? [{ key: 'env', json: env }] : []),
     ],
     exclude: [
       ...getDefaultIgnorePaths(),


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Previous implementation only took env keys into a hash, so changing the env wouldn't affect the fingerprint. This PR changes it in a way that the env information is now recorded as an object of keys and values:
```
{
      "type": "json",
      "key": "json:env",
      "hash": "8488bb5c4dea64136b0047436ee14d7f8d45b919",
      "json": {
        "ABC": "[HASHED:ba7816bf]",
        "S3_ACCESS_KEY_ID": "[HASHED:512aa3ca]",
        "S3_SECRET_ACCESS_KEY": "[HASHED:12fad43b]"
      }
    },
```

To make it safe when debugging on CI, we're now also hashing the values

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
