### PR TITLE
fix: run:ios with non-app targets ordered first

### DIFF
--- a/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/getBuildSettings.ts
@@ -39,7 +39,7 @@ export async function getBuildSettings({
     ? getSimulatorPlatformSDK(platformName)
     : getDevicePlatformSDK(platformName);
 
-  const { stdout: buildSettings } = await spawn(
+  const { stdout: buildSettingsOutput } = await spawn(
     'xcodebuild',
     [
       xcodeProject.isWorkspace ? '-workspace' : '-project',
@@ -64,13 +64,22 @@ export async function getBuildSettings({
     action: string;
     buildSettings: BuildSettings;
     target: string;
-  }[] = JSON.parse(buildSettings).filter(
-    ({ target }: { target: string }) =>
-      target !== 'React' && target !== 'React-Core',
+  }[] = JSON.parse(buildSettingsOutput).filter(
+    ({
+      buildSettings: { WRAPPER_EXTENSION },
+    }: {
+      buildSettings: BuildSettings;
+    }) => WRAPPER_EXTENSION === 'app' || WRAPPER_EXTENSION === 'framework',
   );
   const targets = settings.map(
     ({ target: settingsTarget }: { target: string }) => settingsTarget,
   );
+  if (settings.length === 0) {
+    throw new RockError(
+      `Failed to get build settings for your project. Looking for "app" or "framework" wrapper extension but found: ${wrapperExtension}`,
+    );
+  }
+
   let selectedTarget = targets[0];
 
   if (target) {
@@ -89,31 +98,21 @@ export async function getBuildSettings({
 
   // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
   const targetIndex = targets.indexOf(selectedTarget);
-  const targetSettings = settings[targetIndex].buildSettings;
+  const buildSettings = settings[targetIndex].buildSettings;
 
-  const wrapperExtension = targetSettings.WRAPPER_EXTENSION;
-
-  if (wrapperExtension === 'app' || wrapperExtension === 'framework') {
-    const buildSettings = settings[targetIndex].buildSettings;
-
-    if (!buildSettings) {
-      throw new RockError('Failed to get build settings for your project');
-    }
-
-    const appPath = getBuildPath(buildSettings, platformName);
-    const infoPlistPath = buildSettings.INFOPLIST_PATH;
-    const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
-
-    return {
-      appPath,
-      infoPlistPath: path.join(targetBuildDir, infoPlistPath),
-      bundleIdentifier: buildSettings.PRODUCT_BUNDLE_IDENTIFIER,
-    };
+  if (!buildSettings) {
+    throw new RockError('Failed to get build settings for your project');
   }
 
-  throw new RockError(
-    `Failed to get build settings for your project. Looking for "app" or "framework" wrapper extension but found: ${wrapperExtension}`,
-  );
+  const appPath = getBuildPath(buildSettings, platformName);
+  const infoPlistPath = buildSettings.INFOPLIST_PATH;
+  const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
+
+  return {
+    appPath,
+    infoPlistPath: path.join(targetBuildDir, infoPlistPath),
+    bundleIdentifier: buildSettings.PRODUCT_BUNDLE_IDENTIFIER,
+  };
 }
 
 function getBuildPath(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When the iOS project's scheme has non-app target included and it's ordered as first on the list, our current logic would fail and make you use `--target` flag to fix it.
What we can do, however, is filtering for app or framework (for brownfield case) WRAPPER_EXTENSION first, and avoid processing unrelated targets (which we had some logic before for "React" or "React-Core" included in older RN versions).

Ported from https://github.com/react-native-community/cli/pull/2707

### Test plan

Add a static library target, convert it to a group (for CocoaPods) and update scheme to list it first
<img width="519" height="224" alt="image" src="https://github.com/user-attachments/assets/d5f55480-3b7c-475c-a856-f06b8795ab42" />
