### PR TITLE
chore: cleanup deps

### DIFF
--- a/.changeset/crazy-months-open.md
+++ b/.changeset/crazy-months-open.md
@@ -1,0 +1,6 @@
+---
+'@rock-js/platform-apple-helpers': patch
+'@rock-js/tools': patch
+---
+
+chore: remove unused deps

--- a/packages/platform-apple-helpers/package.json
+++ b/packages/platform-apple-helpers/package.json
@@ -22,7 +22,6 @@
     "@react-native-community/cli-config-apple": "^20.0.0",
     "@rock-js/tools": "^0.11.4",
     "adm-zip": "^0.5.16",
-    "fast-glob": "^3.3.2",
     "fast-xml-parser": "^4.5.0",
     "tslib": "^2.3.0"
   },

--- a/packages/platform-apple-helpers/package.json
+++ b/packages/platform-apple-helpers/package.json
@@ -21,7 +21,6 @@
     "@react-native-community/cli-config": "^20.0.0",
     "@react-native-community/cli-config-apple": "^20.0.0",
     "@rock-js/tools": "^0.11.4",
-    "@types/adm-zip": "^0.5.7",
     "adm-zip": "^0.5.16",
     "fast-glob": "^3.3.2",
     "fast-xml-parser": "^4.5.0",
@@ -29,7 +28,8 @@
   },
   "devDependencies": {
     "@react-native-community/cli-types": "^20.0.0",
-    "@rock-js/config": "^0.11.4"
+    "@rock-js/config": "^0.11.4",
+    "@types/adm-zip": "^0.5.7"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -21,7 +21,6 @@
     "@clack/prompts": "^0.11.0",
     "adm-zip": "^0.5.16",
     "appdirsjs": "^1.2.7",
-    "fast-glob": "^3.3.2",
     "fs-fingerprint": "^0.7.0",
     "is-unicode-supported": "^2.1.0",
     "nano-spawn": "^0.2.0",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "@types/adm-zip": "^0.5.7",
     "adm-zip": "^0.5.16",
     "appdirsjs": "^1.2.7",
     "fast-glob": "^3.3.2",
@@ -32,7 +31,8 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@rock-js/test-helpers": "^0.11.4"
+    "@rock-js/test-helpers": "^0.11.4",
+    "@types/adm-zip": "^0.5.7"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,9 +192,6 @@ importers:
       '@rock-js/tools':
         specifier: ^0.11.4
         version: link:../tools
-      '@types/adm-zip':
-        specifier: ^0.5.7
-        version: 0.5.7
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
@@ -214,6 +211,9 @@ importers:
       '@rock-js/config':
         specifier: ^0.11.4
         version: link:../config
+      '@types/adm-zip':
+        specifier: ^0.5.7
+        version: 0.5.7
 
   packages/platform-ios:
     dependencies:
@@ -384,9 +384,6 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
-      '@types/adm-zip':
-        specifier: ^0.5.7
-        version: 0.5.7
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
@@ -421,6 +418,9 @@ importers:
       '@rock-js/test-helpers':
         specifier: ^0.11.4
         version: link:../test-helpers
+      '@types/adm-zip':
+        specifier: ^0.5.7
+        version: 0.5.7
 
   packages/welcome-screen:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.3
       fast-xml-parser:
         specifier: ^4.5.0
         version: 4.5.3
@@ -390,9 +387,6 @@ importers:
       appdirsjs:
         specifier: ^1.2.7
         version: 1.2.7
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.3
       fs-fingerprint:
         specifier: ^0.7.0
         version: 0.7.0


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Spotted some irregularities in `dependencies`:
- `@types/adm-zip` was a `dep` not a `devDep`
- `fast-glob` dep was no longer used

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

CI tests to pass

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `fast-glob` and moves `@types/adm-zip` to `devDependencies` in `packages/platform-apple-helpers` and `packages/tools`, with changesets marking patch releases.
> 
> - **Dependencies**:
>   - `packages/platform-apple-helpers`:
>     - Remove `fast-glob`.
>     - Move `@types/adm-zip` from `dependencies` to `devDependencies`.
>   - `packages/tools`:
>     - Remove `fast-glob`.
>     - Move `@types/adm-zip` from `dependencies` to `devDependencies`.
> - **Release**:
>   - Add changeset for patch releases of `@rock-js/platform-apple-helpers` and `@rock-js/tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc15b388e8477a2a2b8ae257de7b2cd625bd72a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->